### PR TITLE
Filtering and Pagination for organization events

### DIFF
--- a/lib/mobilize_america/client/events.rb
+++ b/lib/mobilize_america/client/events.rb
@@ -1,8 +1,17 @@
 module MobilizeAmerica
   class Client
     module Events
-      def organization_events(organization_id:, updated_since: nil, zipcode: nil, max_distance_miles: nil)
+      def organization_events(organization_id:, updated_since: nil, max_distance_miles: nil, page: nil, per_page: nil,
+                              zipcode: nil)
         params = {}
+
+        unless page.nil?
+          params[:page] = page
+        end
+
+        unless per_page.nil?
+          params[:per_page] = per_page
+        end
 
         unless updated_since.nil?
           params[:updated_since] = updated_since.to_i

--- a/lib/mobilize_america/client/events.rb
+++ b/lib/mobilize_america/client/events.rb
@@ -1,7 +1,7 @@
 module MobilizeAmerica
   class Client
     module Events
-      def organization_events(organization_id:, updated_since: nil, zipcode: nil)
+      def organization_events(organization_id:, updated_since: nil, zipcode: nil, max_distance_miles: nil)
         params = {}
 
         unless updated_since.nil?
@@ -10,6 +10,10 @@ module MobilizeAmerica
 
         unless zipcode.nil?
           params[:zipcode] = zipcode
+
+          unless max_distance_miles.nil?
+            params[:max_dist] = max_distance_miles
+          end
         end
 
         get(path: "/organizations/#{esc(organization_id)}/events", params: params)

--- a/lib/mobilize_america/client/events.rb
+++ b/lib/mobilize_america/client/events.rb
@@ -1,8 +1,14 @@
 module MobilizeAmerica
   class Client
     module Events
-      def organization_events(organization_id:)
-        get(path: "/organizations/#{esc(organization_id)}/events")
+      def organization_events(organization_id:, updated_since: nil)
+        params = {}
+
+        unless updated_since.nil?
+          params[:updated_since] = updated_since.to_i
+        end
+
+        get(path: "/organizations/#{esc(organization_id)}/events", params: params)
       end
     end
   end

--- a/lib/mobilize_america/client/events.rb
+++ b/lib/mobilize_america/client/events.rb
@@ -1,11 +1,15 @@
 module MobilizeAmerica
   class Client
     module Events
-      def organization_events(organization_id:, updated_since: nil)
+      def organization_events(organization_id:, updated_since: nil, zipcode: nil)
         params = {}
 
         unless updated_since.nil?
           params[:updated_since] = updated_since.to_i
+        end
+
+        unless zipcode.nil?
+          params[:zipcode] = zipcode
         end
 
         get(path: "/organizations/#{esc(organization_id)}/events", params: params)

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -36,5 +36,12 @@ RSpec.describe MobilizeAmerica::Client::Events do
         .to_return(body: response.to_json)
       expect(subject.organization_events(organization_id: org_id, zipcode: zipcode)).to eq response
     end
+
+    it 'should support a max_dist parameter to go with zipcode' do
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {zipcode: '23456', max_dist: 100})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, zipcode: '23456', max_distance_miles: 100)).to eq response
+    end
   end
 end

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe MobilizeAmerica::Client::Events do
         .to_return(body: response.to_json)
       expect(subject.organization_events(organization_id: org_id, updated_since: updated_since)).to eq response
     end
+
+    it 'should support a zipcode parameter' do
+      zipcode = '23456'
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {zipcode: zipcode})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, zipcode: zipcode)).to eq response
+    end
   end
 end

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -20,5 +20,13 @@ RSpec.describe MobilizeAmerica::Client::Events do
       stub_request(:get, expected_url).with(headers: standard_headers).to_return(body: response.to_json)
       expect(subject.organization_events(organization_id: 'foo/bar')).to eq response
     end
+
+    it 'should support an updated_since parameter' do
+      updated_since = Time.new
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {updated_since: updated_since.to_i})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, updated_since: updated_since)).to eq response
+    end
   end
 end

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -43,5 +43,12 @@ RSpec.describe MobilizeAmerica::Client::Events do
         .to_return(body: response.to_json)
       expect(subject.organization_events(organization_id: org_id, zipcode: '23456', max_distance_miles: 100)).to eq response
     end
+
+    it 'should support pagination parameters' do
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {page: 2, per_page: 100})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, page: 2, per_page: 100)).to eq response
+    end
   end
 end


### PR DESCRIPTION
This updates the `organisation_events` call to add support for filtering and pagination parameters:

- `updated_since` date/time
- `zipcode` and optional `max_distance_miles` from that zip code
- `page` and `per_page`

Not included: support for `timeslot_start` and `timeslot_end` filters